### PR TITLE
Update readme to fix secrets permissions needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ Create a new secret in [Secret Manager](https://console.cloud.google.com/securit
 
 #### Firebase Secret Access for Cloud Functions
 The default cloud function IAM user is `<project-id>@appspot.gserviceaccount.com`, it needs to be given the **Secret Manager Secret Accessor** role in order to read data from Secret Manager.
-This can be done at [IAM Admin](https://console.cloud.google.com/iam-admin/iam) page.
+This can be done at [IAM Admin](https://console.cloud.google.com/iam-admin/iam) page. 
+
+**Note**: based on your Firebase configuration you might need to give the role to the `firebase-adminsdk-<random5chars>@project-id.iam.gserviceaccount.com` user instead. Please, check when you get to the [Test](#test) section below.
 
 
 ## Firebase Storage Buckets

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Create a new secret in [Secret Manager](https://console.cloud.google.com/securit
 The default cloud function IAM user is `<project-id>@appspot.gserviceaccount.com`, it needs to be given the **Secret Manager Secret Accessor** role in order to read data from Secret Manager.
 This can be done at [IAM Admin](https://console.cloud.google.com/iam-admin/iam) page. 
 
-**Note**: based on your Firebase configuration you might need to give the role to the `firebase-adminsdk-<random5chars>@project-id.iam.gserviceaccount.com` user instead. Please, check when you get to the [Test](#test) section below.
+**Note**: Depending on your Firebase configuration, the role may need to be delegated to the `firebase-adminsdk-<random5chars>@<project-id>.iam.gserviceaccount.com` user instead.
 
 
 ## Firebase Storage Buckets


### PR DESCRIPTION
According to the docs users need to grant permissions to Secrets to user **@appspot.gserviceaccount.com** but this fails in some Firebase Configurations. Fix requires users to grant permissions to the **Firebase AdminSDK** instead.