### PR TITLE
fix: locks typescript minor semver

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "tslint": "^5.12.0",
-    "typescript": "^3.2.2",
+    "typescript": "~3.7.5",
     "firebase-functions-test": "^0.1.6",
     "mocha": "^7.0.2",
     "@types/mocha": "^7.0.2",


### PR DESCRIPTION
Typescript does not follow semver, and breaking changes can occur across minor versions.

This PR resolves this issue by locking the semver minor of the Typescript direct dependency.

Since the version of Typescript set in `package-lock.json` is `v3.7.5`, the minimum Typescript version in `package.json` has been bumped accordingly.

See: https://github.com/Microsoft/TypeScript/issues/14116

Signed-off-by: Rifa Achrinza <25147899+achrinza@users.noreply.github.com>