### PR TITLE
Add 'project number' to config

### DIFF
--- a/functions/src/config.example.ts
+++ b/functions/src/config.example.ts
@@ -4,6 +4,7 @@ import PinGenerator from "./opentrace/utils/PinGenerator";
 
 const config: FunctionConfig = {
   projectId: "",
+  projectNumber: "",
   regions: [],
   utcOffset: 0,
   authenticator: new Authenticator(),

--- a/functions/src/opentrace/types/FunctionConfig.ts
+++ b/functions/src/opentrace/types/FunctionConfig.ts
@@ -6,6 +6,7 @@ declare type SUPPORTED_REGIONS = "us-central1" | "us-east1" | "us-east4" | "euro
 
 interface FunctionConfig {
   projectId: string // Firebase Project ID
+  projectNumber: string
   regions: SUPPORTED_REGIONS[]
   utcOffset: number | string
   authenticator: Authenticator

--- a/functions/src/opentrace/utils/getEncryptionKey.ts
+++ b/functions/src/opentrace/utils/getEncryptionKey.ts
@@ -2,7 +2,7 @@ import {SecretManagerServiceClient} from "@google-cloud/secret-manager";
 
 import config from "../../config";
 
-const SECRET_KEY = `projects/${config.projectId}/secrets/${config.encryption.keyPath}`;
+const SECRET_KEY = `projects/${config.projectNumber}/secrets/${config.encryption.keyPath}`;
 const SECRET_KEY_DEFAULT_VERSION = `${SECRET_KEY}/versions/${config.encryption.defaultVersion}`;
 
 const getEncryptionKey = async (): Promise<Buffer> => getEncryptionSecret(SECRET_KEY_DEFAULT_VERSION);


### PR DESCRIPTION
When creating firebase projects inside an organization and then
using the SecretManager of GCP, the project-id does not always
match the project id. More often than not, you will get a project
number. In these cases, getEncryptionKey is not finding the
encryption key because the path does not match it. You need
to specify a projectNumber instead. This configuration allows
you to specify the number from GCP so the key can be found